### PR TITLE
Enhance activity tracing by capturing ActivityContext

### DIFF
--- a/Mercurio.Hosting.Tests/Mercurio.Hosting.Tests.csproj
+++ b/Mercurio.Hosting.Tests/Mercurio.Hosting.Tests.csproj
@@ -15,12 +15,12 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-    <PackageReference Include="NUnit" Version="4.3.2"/>
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8"/>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
         <PrivateAssets>all</PrivateAssets>

--- a/Mercurio.Hosting/Mercurio.Hosting.csproj
+++ b/Mercurio.Hosting/Mercurio.Hosting.csproj
@@ -44,7 +44,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
-      <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.0" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.1" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/Mercurio.Hosting/MessagingBackgroundService.cs
+++ b/Mercurio.Hosting/MessagingBackgroundService.cs
@@ -114,7 +114,8 @@ namespace Mercurio.Hosting
         /// </remarks>
         public void PushMessage<TMessage>(TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
         {
-            this.messagesToPush.Enqueue(() => this.MessageClientService.PushAsync(this.ConnectionName, message, exchangeConfiguration, configureProperties, activityName, cancellationToken));
+            var activityContext = Activity.Current?.Context ?? default;
+            this.messagesToPush.Enqueue(() => this.MessageClientService.PushAsync(this.ConnectionName, message, exchangeConfiguration, configureProperties, activityName, activityContext, cancellationToken: cancellationToken));
         }
 
         /// <summary>
@@ -138,7 +139,8 @@ namespace Mercurio.Hosting
         /// </remarks>
         public void PushMessages<TMessage>(IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
         {
-            this.messagesToPush.Enqueue(() => this.MessageClientService.PushAsync(this.ConnectionName, messages, exchangeConfiguration, configureProperties, activityName, cancellationToken));
+            var activityContext = Activity.Current?.Context ?? default;
+            this.messagesToPush.Enqueue(() => this.MessageClientService.PushAsync(this.ConnectionName, messages, exchangeConfiguration, configureProperties, activityName, activityContext, cancellationToken: cancellationToken));
         }
 
         /// <summary>

--- a/Mercurio.Tests.TUnit/Extensions/ServiceCollectionExtensionsTestFixture.cs
+++ b/Mercurio.Tests.TUnit/Extensions/ServiceCollectionExtensionsTestFixture.cs
@@ -18,8 +18,6 @@
 //  </copyright>
 //  ------------------------------------------------------------------------------------------------
 
-using ThrowsExtensions = TUnit.Assertions.AssertConditions.Throws.ThrowsExtensions;
-
 namespace Mercurio.Tests.TUnit.Extensions
 {
     using Mercurio.Configuration.IConfiguration;

--- a/Mercurio.Tests.TUnit/Mercurio.Tests.TUnit.csproj
+++ b/Mercurio.Tests.TUnit/Mercurio.Tests.TUnit.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8"/>
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.8"/>
         <PackageReference Include="Moq" Version="4.20.72"/>
-        <PackageReference Include="TUnit" Version="0.50.0"/>
+        <PackageReference Include="TUnit" Version="0.57.1" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8"/>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <PrivateAssets>all</PrivateAssets>

--- a/Mercurio.Tests.TUnit/Messaging/MessageClientBaseServiceTestFixture.cs
+++ b/Mercurio.Tests.TUnit/Messaging/MessageClientBaseServiceTestFixture.cs
@@ -150,13 +150,14 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
-        /// <param name="cancellationToken">An optional <see cref="System.Threading.CancellationToken" /></param>
-        /// <returns>An awaitable <see cref="System.Threading.Tasks.Task" /></returns>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
+        /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
-        /// By default, the <see cref="RabbitMQ.Client.BasicProperties" /> is configured to use the <see cref="RabbitMQ.Client.DeliveryModes.Persistent" /> mode and sets the
-        /// <see cref="RabbitMQ.Client.BasicProperties.ContentType" /> as 'application/json"
+        /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
+        /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "",CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -175,14 +176,15 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
-        /// <param name="cancellationToken">A possible <see cref="System.Threading.CancellationToken" /></param>
-        /// <returns>An awaitable <see cref="System.Threading.Tasks.Task" /></returns>
-        /// <exception cref="System.ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
+        /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
+        /// <returns>An awaitable <see cref="Task" /></returns>
+        /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
         /// <remarks>
-        /// By default, the <see cref="RabbitMQ.Client.BasicProperties" /> is configured to use the <see cref="RabbitMQ.Client.DeliveryModes.Persistent" /> mode and sets the
-        /// <see cref="RabbitMQ.Client.BasicProperties.ContentType" /> as 'application/json"
+        /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
+        /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }

--- a/Mercurio.Tests.TUnit/Messaging/RabbitMqConnectionProviderTestFixture.cs
+++ b/Mercurio.Tests.TUnit/Messaging/RabbitMqConnectionProviderTestFixture.cs
@@ -18,8 +18,6 @@
 //  </copyright>
 //  ------------------------------------------------------------------------------------------------
 
-using ThrowsExtensions = TUnit.Assertions.AssertConditions.Throws.ThrowsExtensions;
-
 namespace Mercurio.Tests.TUnit.Messaging
 {
     using System.Diagnostics;

--- a/Mercurio.Tests/Mercurio.Tests.csproj
+++ b/Mercurio.Tests/Mercurio.Tests.csproj
@@ -17,12 +17,12 @@
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.8"/>
         <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
-        <PackageReference Include="NUnit" Version="4.3.2"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8"/>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <PrivateAssets>all</PrivateAssets>

--- a/Mercurio.Tests/Messaging/MessageClientBaseServiceTestFixture.cs
+++ b/Mercurio.Tests/Messaging/MessageClientBaseServiceTestFixture.cs
@@ -150,14 +150,14 @@ namespace Mercurio.Tests.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
-        /// <param name="cancellationToken">An optional <see cref="System.Threading.CancellationToken" /></param>
-        /// <returns>An awaitable <see cref="System.Threading.Tasks.Task" /></returns>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
+        /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
-        /// By default, the <see cref="RabbitMQ.Client.BasicProperties" /> is configured to use the
-        /// <see cref="RabbitMQ.Client.DeliveryModes.Persistent" /> mode and sets the
-        /// <see cref="RabbitMQ.Client.BasicProperties.ContentType" /> as 'application/json"
+        /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
+        /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -176,15 +176,15 @@ namespace Mercurio.Tests.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
-        /// <param name="cancellationToken">A possible <see cref="System.Threading.CancellationToken" /></param>
-        /// <returns>An awaitable <see cref="System.Threading.Tasks.Task" /></returns>
-        /// <exception cref="System.ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
+        /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
+        /// <returns>An awaitable <see cref="Task" /></returns>
+        /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
         /// <remarks>
-        /// By default, the <see cref="RabbitMQ.Client.BasicProperties" /> is configured to use the
-        /// <see cref="RabbitMQ.Client.DeliveryModes.Persistent" /> mode and sets the
-        /// <see cref="RabbitMQ.Client.BasicProperties.ContentType" /> as 'application/json"
+        /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
+        /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }

--- a/Mercurio/Mercurio.csproj
+++ b/Mercurio/Mercurio.csproj
@@ -36,11 +36,11 @@
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8"/>
-        <PackageReference Include="Polly" Version="8.6.2"/>
+        <PackageReference Include="Polly" Version="8.6.3" />
         <PackageReference Include="RabbitMQ.Client" Version="7.1.2"/>
         <PackageReference Include="System.Reactive" Version="6.0.1"/>
         <PackageReference Include="System.Text.Json" Version="9.0.8"/>
-        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.1" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Mercurio/Messaging/IMessageClientService.cs
+++ b/Mercurio/Messaging/IMessageClientService.cs
@@ -74,13 +74,14 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="message" /> to the specified queue via the
@@ -96,6 +97,7 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -103,7 +105,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously leases a channel from the pool or creates one if necessary.

--- a/Mercurio/Messaging/MessageClientBaseService.cs
+++ b/Mercurio/Messaging/MessageClientBaseService.cs
@@ -113,13 +113,14 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public abstract Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        public abstract Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="message" /> to the specified queue via the
@@ -135,6 +136,7 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -142,7 +144,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public abstract Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        public abstract Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/Mercurio/Messaging/MessageClientService.cs
+++ b/Mercurio/Messaging/MessageClientService.cs
@@ -124,20 +124,21 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
         {
             if (messages == null)
             {
                 throw new ArgumentException("The messages collection cannot be null", nameof(messages));
             }
 
-            return this.PushInternalAsync(connectionName, messages, exchangeConfiguration, configureProperties, activityName, cancellationToken);
+            return this.PushInternalAsync(connectionName, messages, exchangeConfiguration, configureProperties, activityName, activityContext, cancellationToken);
         }
 
         /// <summary>
@@ -154,6 +155,7 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -161,7 +163,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
         {
             if (Equals(message, default(TMessage)))
             {
@@ -173,7 +175,7 @@ namespace Mercurio.Messaging
                 throw new ArgumentNullException(nameof(exchangeConfiguration), "The exchange configuration cannot be null");
             }
 
-            return this.PushInternalAsync(connectionName, message, exchangeConfiguration, configureProperties, activityName, cancellationToken);
+            return this.PushInternalAsync(connectionName, message, exchangeConfiguration, configureProperties, activityName, activityContext, cancellationToken);
         }
 
         /// <summary>
@@ -289,13 +291,14 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        private async Task PushInternalAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties, string activityName, CancellationToken cancellationToken)
+        private async Task PushInternalAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties, string activityName, ActivityContext activityContext, CancellationToken cancellationToken)
         {
             var activitySource = this.ConnectionProvider.GetRegisteredActivitySource(connectionName);
             var context = Activity.Current == null ? default : Activity.Current.Context;
@@ -307,7 +310,7 @@ namespace Mercurio.Messaging
             foreach (var message in messagesList)
             {
                 var subActivityName = activity == null ? null : $"{activityName} [{messageIndex++}/{messagesList.Count}]";
-                await this.PushAsync(connectionName, message, exchangeConfiguration, configureProperties, subActivityName, cancellationToken);
+                await this.PushAsync(connectionName, message, exchangeConfiguration, configureProperties, subActivityName, activityContext, cancellationToken: cancellationToken);
             }
         }
 
@@ -325,6 +328,7 @@ namespace Mercurio.Messaging
         /// <see cref="Activity" /> information will be sent in the message header.
         /// In case of null or empty, no <see cref="Activity" /> is started
         /// </param>
+        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -332,7 +336,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        private async Task PushInternalAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties, string activityName, CancellationToken cancellationToken)
+        private async Task PushInternalAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties, string activityName, ActivityContext activityContext, CancellationToken cancellationToken)
         {
             Activity activity = null;
 
@@ -351,7 +355,14 @@ namespace Mercurio.Messaging
                 configureProperties?.Invoke(properties);
 
                 var activitySource = this.ConnectionProvider.GetRegisteredActivitySource(connectionName);
-                var context = Activity.Current == null ? default : Activity.Current.Context;
+
+                var context = activityContext;
+
+                if (activityContext == default && Activity.Current != null)
+                {
+                    context = Activity.Current.Context;
+                }
+
                 activity = this.StartActivity(activitySource, context, activityName, ActivityKind.Producer);
                 IntegrateActivityInformation(properties, activity);
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/Mercurio/pulls) open
- [x] I have verified that I am following the Mercurio [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/Mercurio/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Since the BackgroundService enqueues message to push, ActivityContext was lost in some places. This provides abilities to not loose the ActivityContext that could have been set on a listening action, if during that listening action, a message should be pushed.
<!-- Thanks for contributing to Mercurio! -->