### PR TITLE
Fix #21: ActivityName automatically generated

### DIFF
--- a/Mercurio.Hosting/IMessagingBackgroundService.cs
+++ b/Mercurio.Hosting/IMessagingBackgroundService.cs
@@ -20,8 +20,6 @@
 
 namespace Mercurio.Hosting
 {
-    using System.Diagnostics;
-
     using Mercurio.Messaging;
     using Mercurio.Model;
 
@@ -47,18 +45,13 @@ namespace Mercurio.Hosting
         /// <param name="message">The <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        void PushMessage<TMessage>(TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        void PushMessage<TMessage>(TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="messages" /> to the specified queue via the
@@ -68,17 +61,12 @@ namespace Mercurio.Hosting
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        void PushMessages<TMessage>(IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        void PushMessages<TMessage>(IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
     }
 }

--- a/Mercurio.Tests.TUnit/Messaging/MessageClientBaseServiceTestFixture.cs
+++ b/Mercurio.Tests.TUnit/Messaging/MessageClientBaseServiceTestFixture.cs
@@ -20,11 +20,8 @@
 
 namespace Mercurio.Tests.TUnit.Messaging
 {
-    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
-    using global::TUnit.Assertions.AssertConditions.Throws;
-    
     using Mercurio.Messaging;
     using Mercurio.Model;
     using Mercurio.Provider;
@@ -108,13 +105,9 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// <typeparam name="TMessage">The type of messages to listen for.</typeparam>
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>An observable sequence of messages.</returns>
-        public override Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -125,13 +118,9 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="onReceiveAsync">The <see cref="AsyncEventHandler{TEvent}" /></param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <return>A <see cref="Task" /> of <see cref="IDisposable" /></return>
-        public override Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -145,19 +134,13 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -171,12 +154,6 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// <param name="message">The <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -184,9 +161,9 @@ namespace Mercurio.Tests.TUnit.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException();        
         }
     }
 }

--- a/Mercurio.Tests/Messaging/MessageClientBaseServiceTestFixture.cs
+++ b/Mercurio.Tests/Messaging/MessageClientBaseServiceTestFixture.cs
@@ -20,7 +20,6 @@
 
 namespace Mercurio.Tests.Messaging
 {
-    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
     using Mercurio.Messaging;
@@ -108,13 +107,9 @@ namespace Mercurio.Tests.Messaging
         /// <typeparam name="TMessage">The type of messages to listen for.</typeparam>
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>An observable sequence of messages.</returns>
-        public override Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -125,13 +120,9 @@ namespace Mercurio.Tests.Messaging
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="onReceiveAsync">The <see cref="AsyncEventHandler{TEvent}" /></param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <return>A <see cref="Task" /> of <see cref="IDisposable" /></return>
-        public override Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -145,19 +136,13 @@ namespace Mercurio.Tests.Messaging
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }
@@ -171,12 +156,6 @@ namespace Mercurio.Tests.Messaging
         /// <param name="message">The <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -184,7 +163,7 @@ namespace Mercurio.Tests.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException();
         }

--- a/Mercurio.Tests/Messaging/MessageClientServiceTestFixture.cs
+++ b/Mercurio.Tests/Messaging/MessageClientServiceTestFixture.cs
@@ -44,7 +44,7 @@ namespace Mercurio.Tests.Messaging
         private const string SecondConnectionName = "RabbitMQConnection2";
         private const string FirstSentMessage = "Hello World!";
         private const string SecondSentMessage = "Hello World!";
-        private const int TimeOut = 200;
+        private const int TimeOut = 300;
         
         [SetUp]
         public void Setup()

--- a/Mercurio.Tests/Messaging/MessageClientServiceTestFixture.cs
+++ b/Mercurio.Tests/Messaging/MessageClientServiceTestFixture.cs
@@ -338,7 +338,7 @@ namespace Mercurio.Tests.Messaging
            activities.Add(newActivity);
            
            var exchangeConfiguration = new DefaultExchangeConfiguration("DefaultChannelForActivity");
-           var listenObservable = await this.firstService.ListenAsync<string>(FirstConnectionName, exchangeConfiguration, "FirstActivity");
+           var listenObservable = await this.firstService.ListenAsync<string>(FirstConnectionName, exchangeConfiguration);
            var firstTaskCompletion = new TaskCompletionSource<string>();
            
            using var _ = listenObservable.Subscribe(message =>
@@ -348,7 +348,7 @@ namespace Mercurio.Tests.Messaging
            
            await Task.Delay(TimeOut);
             
-           await this.secondService.PushAsync(SecondConnectionName, FirstSentMessage, exchangeConfiguration, activityName: "Push request");
+           await this.secondService.PushAsync(SecondConnectionName, FirstSentMessage, exchangeConfiguration);
            await firstTaskCompletion.Task;
            await Task.Delay(100);
            
@@ -357,9 +357,9 @@ namespace Mercurio.Tests.Messaging
                Assert.That(activities, Has.Count.EqualTo(3));
                Assert.That(activities.ElementAt(0).OperationName, Is.EqualTo("Parent"));
                Assert.That(activities.ElementAt(0).Status, Is.EqualTo(ActivityStatusCode.Unset));
-               Assert.That(activities.ElementAt(1).OperationName, Is.EqualTo("Push request"));
+               Assert.That(activities.ElementAt(1).OperationName, Is.EqualTo("Push String [Queue: DefaultChannelForActivity]"));
                Assert.That(activities.ElementAt(1).Status, Is.EqualTo(ActivityStatusCode.Ok));
-               Assert.That(activities.ElementAt(2).OperationName, Is.EqualTo("FirstActivity"));
+               Assert.That(activities.ElementAt(2).OperationName, Is.EqualTo("String Received [Queue: DefaultChannelForActivity]"));
                Assert.That(activities.ElementAt(2).Status, Is.EqualTo(ActivityStatusCode.Ok));
            }
            
@@ -367,7 +367,7 @@ namespace Mercurio.Tests.Messaging
             
            void ActivityOnCurrentChanged(object sender, ActivityChangedEventArgs e)
            {
-               if (e.Current != null && e.Current.Source.Name is FirstConnectionName or SecondConnectionName)
+               if (e.Current is { Source.Name: FirstConnectionName or SecondConnectionName })
                {
                    activities.Add(e.Current!);
                }
@@ -396,23 +396,24 @@ namespace Mercurio.Tests.Messaging
            
            await Task.Delay(TimeOut);
             
-           await this.secondService.PushAsync(SecondConnectionName, [FirstSentMessage,SecondSentMessage], exchangeConfiguration, activityName: "Push request");
+           await this.secondService.PushAsync(SecondConnectionName, [FirstSentMessage,SecondSentMessage], exchangeConfiguration);
            await firstTaskCompletion.Task;
 
            using (Assert.EnterMultipleScope())
            { 
-               Assert.That(activities, Has.Count.EqualTo(4));
+               Assert.That(activities, Has.Count.EqualTo(5));
                Assert.That(activities.ElementAt(0).OperationName, Is.EqualTo("Parent"));
-               Assert.That(activities.ElementAt(1).OperationName, Is.EqualTo("Push request"));
-               Assert.That(activities.ElementAt(2).OperationName, Is.EqualTo("Push request [1/2]"));
-               Assert.That(activities.ElementAt(3).OperationName, Is.EqualTo("Push request [2/2]"));
+               Assert.That(activities.ElementAt(1).OperationName, Is.EqualTo("Push String collection [Queue: DefaultChannelForActivity]"));
+               Assert.That(activities.ElementAt(2).OperationName, Is.EqualTo("Push String collection [Queue: DefaultChannelForActivity] [1/2]"));
+               Assert.That(activities.ElementAt(3).OperationName, Is.EqualTo("Push String collection [Queue: DefaultChannelForActivity] [2/2]"));
+               Assert.That(activities.ElementAt(4).OperationName, Is.EqualTo("String Received [Queue: DefaultChannelForActivity]"));
            }
            
            Activity.CurrentChanged -= ActivityOnCurrentChanged;
             
            void ActivityOnCurrentChanged(object sender, ActivityChangedEventArgs e)
            {
-               if (e.Current != null && e.Current.Source.Name is FirstConnectionName or SecondConnectionName)
+               if (e.Current is { Source.Name: FirstConnectionName or SecondConnectionName })
                {
                    activities.Add(e.Current!);
                }

--- a/Mercurio.Tests/Messaging/RpcCommunicationTestFixture.cs
+++ b/Mercurio.Tests/Messaging/RpcCommunicationTestFixture.cs
@@ -126,8 +126,8 @@ namespace Mercurio.Tests.Messaging
 
             using var newActivity = new Activity("Parent").Start();
             activities.Add(newActivity);
-            var disposable = await this.rpcServerService.ListenForRequestAsync<int, string>(FirstConnectionName, listeningQueue, OnReceiveAsync, activityName:"Server");
-            var clientRequestObservable = await this.rpcClientService.SendRequestAsync(SecondConnectionName, listeningQueue, 41, activityName:"Client" );
+            var disposable = await this.rpcServerService.ListenForRequestAsync<int, string>(FirstConnectionName, listeningQueue, OnReceiveAsync);
+            var clientRequestObservable = await this.rpcClientService.SendRequestAsync(SecondConnectionName, listeningQueue, 41);
             var taskComplettion = new TaskCompletionSource<string>();
             clientRequestObservable.Subscribe(result => taskComplettion.SetResult(result));
 
@@ -139,9 +139,9 @@ namespace Mercurio.Tests.Messaging
             {
                 Assert.That(activities, Has.Count.EqualTo(4));
                 Assert.That(activities.ElementAt(0).OperationName, Is.EqualTo("Parent"));
-                Assert.That(activities.ElementAt(1).OperationName, Is.EqualTo("Client - Request"));
-                Assert.That(activities.ElementAt(2).OperationName, Is.EqualTo("Server"));
-                Assert.That(activities.ElementAt(3).OperationName, Is.EqualTo("Client"));
+                Assert.That(activities.ElementAt(1).OperationName, Is.EqualTo("RPC Int32 To rpc_request - Request"));
+                Assert.That(activities.ElementAt(2).OperationName, Is.EqualTo("RPC Request Handle Int32 On rpc_request"));
+                Assert.That(activities.ElementAt(3).OperationName, Is.EqualTo("RPC Int32 To rpc_request - Callback"));
 
                 foreach (var activity in activities)
                 {
@@ -154,7 +154,7 @@ namespace Mercurio.Tests.Messaging
             
             void ActivityOnCurrentChanged(object sender, ActivityChangedEventArgs e)
             {
-                if (e.Current != null && e.Current.Source.Name is FirstConnectionName or SecondConnectionName)
+                if (e.Current is { Source.Name: FirstConnectionName or SecondConnectionName })
                 {
                     activities.Add(e.Current!);
                 }

--- a/Mercurio.Tests/Messaging/RuntimeTracingTestFixture.cs
+++ b/Mercurio.Tests/Messaging/RuntimeTracingTestFixture.cs
@@ -134,8 +134,8 @@ namespace Mercurio.Tests.Messaging
             var activitySource = new ActivitySource("Local");
 
             using var newActivity = activitySource.StartActivity("Parent", ActivityKind.Consumer, null);
-            var disposable = await this.rpcServerService.ListenForRequestAsync<int, string>(FirstConnectionName, listeningQueue, OnReceiveAsync, activityName:"Server");
-            var clientRequestObservable = await this.rpcClientService.SendRequestAsync(SecondConnectionName, listeningQueue, 41, activityName:"Client" );
+            var disposable = await this.rpcServerService.ListenForRequestAsync<int, string>(FirstConnectionName, listeningQueue, OnReceiveAsync);
+            var clientRequestObservable = await this.rpcClientService.SendRequestAsync(SecondConnectionName, listeningQueue, 41);
             var taskComplettion = new TaskCompletionSource<string>();
             clientRequestObservable.Subscribe(result => taskComplettion.SetResult(result));
 

--- a/Mercurio/Messaging/IMessageClientService.cs
+++ b/Mercurio/Messaging/IMessageClientService.cs
@@ -20,8 +20,6 @@
 
 namespace Mercurio.Messaging
 {
-    using System.Diagnostics;
-
     using Mercurio.Model;
 
     using RabbitMQ.Client;
@@ -38,13 +36,9 @@ namespace Mercurio.Messaging
         /// <typeparam name="TMessage">The type of messages to listen for.</typeparam>
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>An observable sequence of messages.</returns>
-        Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, string activityName = "", CancellationToken cancellationToken = default) where TMessage : class;
+        Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, CancellationToken cancellationToken = default) where TMessage : class;
 
         /// <summary>
         /// Adds a listener to the specified queue
@@ -52,13 +46,9 @@ namespace Mercurio.Messaging
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="onReceiveAsync">The <see cref="AsyncEventHandler{TEvent}" /></param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <return>A <see cref="Task" /> of <see cref="IDisposable" /></return>
-        Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, string activityName = "", CancellationToken cancellationToken = default);
+        Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="messages" /> to the specified queue via the
@@ -69,19 +59,13 @@ namespace Mercurio.Messaging
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
+        Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="message" /> to the specified queue via the
@@ -92,12 +76,6 @@ namespace Mercurio.Messaging
         /// <param name="message">The <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -105,7 +83,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
+        Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Asynchronously leases a channel from the pool or creates one if necessary.

--- a/Mercurio/Messaging/IRpcClientService.cs
+++ b/Mercurio/Messaging/IRpcClientService.cs
@@ -20,8 +20,6 @@
 
 namespace Mercurio.Messaging
 {
-    using System.Diagnostics;
-
     using RabbitMQ.Client;
 
     /// <summary>
@@ -37,10 +35,6 @@ namespace Mercurio.Messaging
         /// <param name="rpcServerQueueName">The name of the queue that is used by the server to listen after request</param>
         /// <param name="request">The <typeparamref name="TRequest" /> that should be sent to the server</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when the server response has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task{T}" /> with the observable that will track the server response</returns>
         /// <typeparam name="TRequest">Any type that correspond to the kind of request to be sent to the server</typeparam>
@@ -51,6 +45,6 @@ namespace Mercurio.Messaging
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to set the <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        Task<IObservable<TResponse>> SendRequestAsync<TRequest>(string connectionName, string rpcServerQueueName, TRequest request, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        Task<IObservable<TResponse>> SendRequestAsync<TRequest>(string connectionName, string rpcServerQueueName, TRequest request, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
     }
 }

--- a/Mercurio/Messaging/IRpcServerService.cs
+++ b/Mercurio/Messaging/IRpcServerService.cs
@@ -20,8 +20,6 @@
 
 namespace Mercurio.Messaging
 {
-    using System.Diagnostics;
-
     using RabbitMQ.Client;
 
     /// <summary>
@@ -36,10 +34,6 @@ namespace Mercurio.Messaging
         /// <param name="queueName">The name of the listening queue</param>
         /// <param name="onReceiveAsync">The action that should be executed when a request is received</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <typeparam name="TRequest">Any type that correspond to the kind of request to be processed</typeparam>
         /// <typeparam name="TResponse">Any type that correspond to the kind of response that has to be send back</typeparam>
@@ -51,6 +45,6 @@ namespace Mercurio.Messaging
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to set the <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        Task<IDisposable> ListenForRequestAsync<TRequest, TResponse>(string connectionName, string queueName, Func<TRequest, Task<TResponse>> onReceiveAsync, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default);
+        Task<IDisposable> ListenForRequestAsync<TRequest, TResponse>(string connectionName, string queueName, Func<TRequest, Task<TResponse>> onReceiveAsync, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
     }
 }

--- a/Mercurio/Messaging/MessageClientBaseService.cs
+++ b/Mercurio/Messaging/MessageClientBaseService.cs
@@ -77,13 +77,9 @@ namespace Mercurio.Messaging
         /// <typeparam name="TMessage">The type of messages to listen for.</typeparam>
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>An observable sequence of messages.</returns>
-        public abstract Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, string activityName = "", CancellationToken cancellationToken = default) where TMessage : class;
+        public abstract Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, CancellationToken cancellationToken = default) where TMessage : class;
 
         /// <summary>
         /// Adds a listener to the specified queue
@@ -91,13 +87,9 @@ namespace Mercurio.Messaging
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="onReceiveAsync">The <see cref="AsyncEventHandler{TEvent}" /></param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <return>A <see cref="Task" /> of <see cref="IDisposable" /></return>
-        public abstract Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, string activityName = "", CancellationToken cancellationToken = default);
+        public abstract Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="messages" /> to the specified queue via the
@@ -108,19 +100,13 @@ namespace Mercurio.Messaging
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public abstract Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
+        public abstract Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Pushes the specified <paramref name="message" /> to the specified queue via the
@@ -131,12 +117,6 @@ namespace Mercurio.Messaging
         /// <param name="message">The <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -144,7 +124,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public abstract Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default);
+        public abstract Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/Mercurio/Messaging/MessageClientService.cs
+++ b/Mercurio/Messaging/MessageClientService.cs
@@ -72,20 +72,16 @@ namespace Mercurio.Messaging
         /// <typeparam name="TMessage">The type of messages to listen for.</typeparam>
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>An observable sequence of messages.</returns>
-        public override Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task<IObservable<TMessage>> ListenAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, CancellationToken cancellationToken = default)
         {
             if (exchangeConfiguration == null)
             {
                 throw new ArgumentNullException(nameof(exchangeConfiguration), "The exchange configuration cannot be null");
             }
 
-            return this.ListenInternalAsync<TMessage>(connectionName, exchangeConfiguration, activityName, cancellationToken);
+            return this.ListenInternalAsync<TMessage>(connectionName, exchangeConfiguration, cancellationToken);
         }
 
         /// <summary>
@@ -94,20 +90,16 @@ namespace Mercurio.Messaging
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="onReceiveAsync">The <see cref="AsyncEventHandler{TEvent}" /></param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <return>A <see cref="Task" /> of <see cref="IDisposable" /></return>
-        public override Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, string activityName = "", CancellationToken cancellationToken = default)
+        public override Task<IDisposable> AddListenerAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, CancellationToken cancellationToken = default)
         {
             if (exchangeConfiguration == null)
             {
                 throw new ArgumentNullException(nameof(exchangeConfiguration), "The exchange configuration cannot be null");
             }
 
-            return this.AddListenerInternalAsync(connectionName, exchangeConfiguration, onReceiveAsync, activityName, cancellationToken);
+            return this.AddListenerInternalAsync(connectionName, exchangeConfiguration, onReceiveAsync, cancellationToken);
         }
 
         /// <summary>
@@ -119,26 +111,20 @@ namespace Mercurio.Messaging
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
             if (messages == null)
             {
                 throw new ArgumentException("The messages collection cannot be null", nameof(messages));
             }
 
-            return this.PushInternalAsync(connectionName, messages, exchangeConfiguration, configureProperties, activityName, activityContext, cancellationToken);
+            return this.PushMultipleInternalAsync(connectionName, messages, exchangeConfiguration, configureProperties, cancellationToken);
         }
 
         /// <summary>
@@ -150,12 +136,6 @@ namespace Mercurio.Messaging
         /// <param name="message">The <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <exception cref="ArgumentNullException">When the provided <typeparamref name="TMessage" /> is null</exception>
@@ -163,7 +143,7 @@ namespace Mercurio.Messaging
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, string activityName = "", ActivityContext activityContext = default, CancellationToken cancellationToken = default)
+        public override Task PushAsync<TMessage>(string connectionName, TMessage message, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
             if (Equals(message, default(TMessage)))
             {
@@ -175,7 +155,10 @@ namespace Mercurio.Messaging
                 throw new ArgumentNullException(nameof(exchangeConfiguration), "The exchange configuration cannot be null");
             }
 
-            return this.PushInternalAsync(connectionName, message, exchangeConfiguration, configureProperties, activityName, activityContext, cancellationToken);
+            var context = Activity.Current == null ? default : Activity.Current.Context;
+            var activityName = $"Push {typeof(TMessage).Name} [{exchangeConfiguration}]";
+
+            return this.PushInternalAsync(connectionName, message, exchangeConfiguration, configureProperties, activityName, context, cancellationToken);
         }
 
         /// <summary>
@@ -184,13 +167,9 @@ namespace Mercurio.Messaging
         /// <typeparam name="TMessage">The type of messages to listen for.</typeparam>
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">Cancellation token for the asynchronous operation.</param>
         /// <returns>An observable sequence of messages.</returns>
-        private async Task<IObservable<TMessage>> ListenInternalAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, string activityName, CancellationToken cancellationToken)
+        private async Task<IObservable<TMessage>> ListenInternalAsync<TMessage>(string connectionName, IExchangeConfiguration exchangeConfiguration, CancellationToken cancellationToken)
             where TMessage : class
         {
             var channelLease = await this.LeaseChannelAsync(connectionName, cancellationToken);
@@ -198,7 +177,7 @@ namespace Mercurio.Messaging
 
             return Observable.Create<TMessage>(async observer =>
             {
-                var disposables = await this.InitializeListenerAsync(observer, channelLease.Channel, exchangeConfiguration, activitySource, activityName, cancellationToken);
+                var disposables = await this.InitializeListenerAsync(observer, channelLease.Channel, exchangeConfiguration, activitySource, cancellationToken);
 
                 return Disposable.Create(() =>
                 {
@@ -214,13 +193,9 @@ namespace Mercurio.Messaging
         /// <param name="connectionName">The name of the registered connection to use.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="onReceiveAsync">The <see cref="AsyncEventHandler{TEvent}" /></param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <return>A <see cref="Task" /> of <see cref="IDisposable" /></return>
-        private async Task<IDisposable> AddListenerInternalAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, string activityName, CancellationToken cancellationToken)
+        private async Task<IDisposable> AddListenerInternalAsync(string connectionName, IExchangeConfiguration exchangeConfiguration, AsyncEventHandler<BasicDeliverEventArgs> onReceiveAsync, CancellationToken cancellationToken)
         {
             AsyncEventingBasicConsumer consumer = null;
             ChannelLease channelLease = default;
@@ -259,6 +234,7 @@ namespace Mercurio.Messaging
 
             async Task OnMessageReceiveAsync(object sender, BasicDeliverEventArgs m)
             {
+                var activityName = $"On Received [{exchangeConfiguration}]";
                 var activity = this.StartActivity(m, activitySource, activityName);
 
                 try
@@ -286,22 +262,19 @@ namespace Mercurio.Messaging
         /// <param name="messages">The collection of <typeparamref name="TMessage" /> to push</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized before sending the message, for traceability.
-        /// <see cref="Activity" /> information will be sent in the message header.
-        /// In case of null or empty, no <see cref="Activity" /> is started
-        /// </param>
-        /// <param name="activityContext">An optional <see cref="ActivityContext"/>. If not set, current context will be based on <see cref="Activity.Current"/></param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to use the <see cref="DeliveryModes.Persistent" /> mode and sets the
         /// <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        private async Task PushInternalAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties, string activityName, ActivityContext activityContext, CancellationToken cancellationToken)
+        private async Task PushMultipleInternalAsync<TMessage>(string connectionName, IEnumerable<TMessage> messages, IExchangeConfiguration exchangeConfiguration, Action<BasicProperties> configureProperties, CancellationToken cancellationToken)
         {
             var activitySource = this.ConnectionProvider.GetRegisteredActivitySource(connectionName);
+
             var context = Activity.Current == null ? default : Activity.Current.Context;
+            var activityName = $"Push {typeof(TMessage).Name} collection [{exchangeConfiguration}]";
+
             using var activity = this.StartActivity(activitySource, context, activityName, ActivityKind.Producer);
 
             var messagesList = messages.ToList();
@@ -310,7 +283,7 @@ namespace Mercurio.Messaging
             foreach (var message in messagesList)
             {
                 var subActivityName = activity == null ? null : $"{activityName} [{messageIndex++}/{messagesList.Count}]";
-                await this.PushAsync(connectionName, message, exchangeConfiguration, configureProperties, subActivityName, activityContext, cancellationToken: cancellationToken);
+                await this.PushInternalAsync(connectionName, message, exchangeConfiguration, configureProperties, subActivityName, context, cancellationToken: cancellationToken);
             }
         }
 
@@ -401,13 +374,9 @@ namespace Mercurio.Messaging
         /// <param name="channel">The RabbitMQ channel.</param>
         /// <param name="exchangeConfiguration">The <see cref="IExchangeConfiguration" /> that should be used to configure the queue and exchange to use</param>
         /// <param name="activitySource">The <see cref="ActivitySource" /> that will be use to start an <see cref="Activity" />, if applicable</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken" /></param>
         /// <returns>A disposable to clean up resources.</returns>
-        private async Task<IDisposable> InitializeListenerAsync<TMessage>(IObserver<TMessage> observer, IChannel channel, IExchangeConfiguration exchangeConfiguration, ActivitySource activitySource, string activityName,
+        private async Task<IDisposable> InitializeListenerAsync<TMessage>(IObserver<TMessage> observer, IChannel channel, IExchangeConfiguration exchangeConfiguration, ActivitySource activitySource,
             CancellationToken cancellationToken = default) where TMessage : class
         {
             AsyncEventingBasicConsumer consumer = null;
@@ -444,6 +413,7 @@ namespace Mercurio.Messaging
 
             async Task ConsumerOnReceivedAsync(object o, BasicDeliverEventArgs message)
             {
+                var activityName = $"{typeof(TMessage).Name} Received [{exchangeConfiguration}]";
                 var activity = this.StartActivity(message, activitySource, activityName);
 
                 try
@@ -452,7 +422,7 @@ namespace Mercurio.Messaging
                     var content = await this.SerializationProviderService.ResolveDeserializer(message.BasicProperties.ContentType).DeserializeAsync<TMessage>(stream, cancellationToken);
                     observer.OnNext(content);
                     activity?.SetStatus(ActivityStatusCode.Ok);
-                    
+
                     await Task.CompletedTask;
                 }
                 catch (Exception ex)

--- a/Mercurio/Messaging/RpcServerService.cs
+++ b/Mercurio/Messaging/RpcServerService.cs
@@ -60,10 +60,6 @@ namespace Mercurio.Messaging
         /// <param name="queueName">The name of the listening queue</param>
         /// <param name="onReceiveAsync">The action that should be executed when a request is received</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <typeparam name="TRequest">Any type that correspond to the kind of request to be processed</typeparam>
         /// <typeparam name="TResponse">Any type that correspond to the kind of response that has to be send back</typeparam>
@@ -75,7 +71,7 @@ namespace Mercurio.Messaging
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to set the <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        public Task<IDisposable> ListenForRequestAsync<TRequest, TResponse>(string connectionName, string queueName, Func<TRequest, Task<TResponse>> onReceiveAsync, Action<BasicProperties> configureProperties = null, string activityName = "", CancellationToken cancellationToken = default)
+        public Task<IDisposable> ListenForRequestAsync<TRequest, TResponse>(string connectionName, string queueName, Func<TRequest, Task<TResponse>> onReceiveAsync, Action<BasicProperties> configureProperties = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
@@ -87,7 +83,7 @@ namespace Mercurio.Messaging
                 throw new ArgumentNullException(nameof(onReceiveAsync), "The OnReceiveAsync cannot be null.");
             }
 
-            return this.ListenForRequestInternalAsync(connectionName, queueName, onReceiveAsync, configureProperties, activityName, cancellationToken);
+            return this.ListenForRequestInternalAsync(connectionName, queueName, onReceiveAsync, configureProperties, cancellationToken);
         }
 
         /// <summary>
@@ -97,10 +93,6 @@ namespace Mercurio.Messaging
         /// <param name="queueName">The name of the listening queue</param>
         /// <param name="onReceiveAsync">The action that should be executed when a request is received</param>
         /// <param name="configureProperties">Possible action to configure additional properties</param>
-        /// <param name="activityName">
-        /// Defines the name of an <see cref="Activity" /> that should be initialized when a message has been received, for traceability. In case of null or empty, no
-        /// <see cref="Activity" /> is started
-        /// </param>
         /// <param name="cancellationToken">A possible <see cref="CancellationToken" /></param>
         /// <typeparam name="TRequest">Any type that correspond to the kind of request to be processed</typeparam>
         /// <typeparam name="TResponse">Any type that correspond to the kind of response that has to be send back</typeparam>
@@ -108,12 +100,13 @@ namespace Mercurio.Messaging
         /// <remarks>
         /// By default, the <see cref="BasicProperties" /> is configured to set the <see cref="BasicProperties.ContentType" /> as 'application/json"
         /// </remarks>
-        private async Task<IDisposable> ListenForRequestInternalAsync<TRequest, TResponse>(string connectionName, string queueName, Func<TRequest, Task<TResponse>> onReceiveAsync, Action<BasicProperties> configureProperties, string activityName, CancellationToken cancellationToken)
+        private async Task<IDisposable> ListenForRequestInternalAsync<TRequest, TResponse>(string connectionName, string queueName, Func<TRequest, Task<TResponse>> onReceiveAsync, Action<BasicProperties> configureProperties, CancellationToken cancellationToken)
         {
             AsyncEventingBasicConsumer consumer = null;
             ChannelLease channelLease = default;
             ActivitySource activitySource = null;
-
+            var activityName = $"RPC Request Handle {typeof(TRequest).Name} On {queueName}";
+            
             try
             {
                 channelLease = await this.ConnectionProvider.LeaseChannelAsync(connectionName, cancellationToken);

--- a/Mercurio/Model/BaseExchangeConfiguration.cs
+++ b/Mercurio/Model/BaseExchangeConfiguration.cs
@@ -76,5 +76,28 @@ namespace Mercurio.Model
         /// <param name="isDeclareForPush">Asserts that the declaration is used for a push action</param>
         /// <returns>An awaitable <see cref="Task" /></returns>
         public abstract Task EnsureQueueAndExchangeAreDeclaredAsync(IChannel channel, bool isDeclareForPush);
+
+        /// <summary>Returns a string that represents the current object.</summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            var content = new List<string>();
+
+            if (!string.IsNullOrEmpty(this.ExchangeName))
+            {
+                content.Add($"Exchange: {this.ExchangeName}");
+            }
+            else if(!string.IsNullOrEmpty(this.QueueName))
+            {
+                content.Add($"Queue: {this.QueueName}");
+            }
+
+            if (!string.IsNullOrEmpty(this.RoutingKey))
+            {
+                content.Add($"RoutingKey: {this.RoutingKey}");
+            }
+            
+            return string.Join(" ", content);
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/Mercurio/pulls) open
- [x] I have verified that I am following the Mercurio [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/Mercurio/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #21

Remove ActivityName/ActivityContext and automatically generated names to not have to be too verbose during Mercurio usage
<!-- Thanks for contributing to Mercurio! -->