### PR TITLE
Add extension tests and improve null checks

### DIFF
--- a/Mercurio.Tests/Extensions/BasicDeliverEventArgsExtensionsTestFixture.cs
+++ b/Mercurio.Tests/Extensions/BasicDeliverEventArgsExtensionsTestFixture.cs
@@ -1,0 +1,63 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="BasicDeliverEventArgsExtensionsTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright 2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace Mercurio.Tests.Extensions
+{
+    using Mercurio.Extensions;
+    using RabbitMQ.Client;
+
+    using System.Collections.Generic;
+    using System.Text;
+
+    [TestFixture]
+    public class BasicDeliverEventArgsExtensionsTestFixture
+    {
+        [Test]
+        public void VerifyNullArgumentsThrow()
+        {
+            IReadOnlyBasicProperties properties = null;
+            Assert.That(() => properties.TryReadHeader<string>("header", out _), Throws.ArgumentNullException);
+
+            var basicProperties = new BasicProperties();
+            Assert.That(() => basicProperties.TryReadHeader<string>(null, out _), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void VerifyHeaderRead()
+        {
+            var properties = new BasicProperties
+            {
+                Headers = new Dictionary<string, object>
+                {
+                    { "string", "value" },
+                    { "bytes", Encoding.UTF8.GetBytes("hello") }
+                }
+            };
+
+            Assert.That(properties.TryReadHeader<string>("string", out var text), Is.True);
+            Assert.That(text, Is.EqualTo("value"));
+
+            Assert.That(properties.TryReadHeader<string>("bytes", out var fromBytes), Is.True);
+            Assert.That(fromBytes, Is.EqualTo("hello"));
+
+            Assert.That(properties.TryReadHeader<string>("missing", out _), Is.False);
+        }
+    }
+}

--- a/Mercurio.Tests/Extensions/BasicDeliverEventArgsExtensionsTestFixture.cs
+++ b/Mercurio.Tests/Extensions/BasicDeliverEventArgsExtensionsTestFixture.cs
@@ -20,11 +20,12 @@
 
 namespace Mercurio.Tests.Extensions
 {
-    using Mercurio.Extensions;
-    using RabbitMQ.Client;
-
     using System.Collections.Generic;
     using System.Text;
+
+    using Mercurio.Extensions;
+
+    using RabbitMQ.Client;
 
     [TestFixture]
     public class BasicDeliverEventArgsExtensionsTestFixture
@@ -32,11 +33,14 @@ namespace Mercurio.Tests.Extensions
         [Test]
         public void VerifyNullArgumentsThrow()
         {
-            IReadOnlyBasicProperties properties = null;
-            Assert.That(() => properties.TryReadHeader<string>("header", out _), Throws.ArgumentNullException);
+            using (Assert.EnterMultipleScope())
+            {
+                IReadOnlyBasicProperties properties = null;
+                Assert.That(() => properties.TryReadHeader<string>("header", out _), Throws.ArgumentNullException);
 
-            var basicProperties = new BasicProperties();
-            Assert.That(() => basicProperties.TryReadHeader<string>(null, out _), Throws.ArgumentNullException);
+                var basicProperties = new BasicProperties();
+                Assert.That(() => basicProperties.TryReadHeader<string>(null, out _), Throws.ArgumentNullException);
+            }
         }
 
         [Test]
@@ -51,13 +55,16 @@ namespace Mercurio.Tests.Extensions
                 }
             };
 
-            Assert.That(properties.TryReadHeader<string>("string", out var text), Is.True);
-            Assert.That(text, Is.EqualTo("value"));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(properties.TryReadHeader<string>("string", out var text), Is.True);
+                Assert.That(text, Is.EqualTo("value"));
 
-            Assert.That(properties.TryReadHeader<string>("bytes", out var fromBytes), Is.True);
-            Assert.That(fromBytes, Is.EqualTo("hello"));
+                Assert.That(properties.TryReadHeader<string>("bytes", out var fromBytes), Is.True);
+                Assert.That(fromBytes, Is.EqualTo("hello"));
 
-            Assert.That(properties.TryReadHeader<string>("missing", out _), Is.False);
+                Assert.That(properties.TryReadHeader<string>("missing", out _), Is.False);
+            }
         }
     }
 }

--- a/Mercurio.Tests/Extensions/ObservableExtensionsTestFixture.cs
+++ b/Mercurio.Tests/Extensions/ObservableExtensionsTestFixture.cs
@@ -20,12 +20,12 @@
 
 namespace Mercurio.Tests.Extensions
 {
-    using Mercurio.Extensions;
-
     using System;
     using System.Collections.Generic;
     using System.Reactive.Subjects;
     using System.Threading.Tasks;
+
+    using Mercurio.Extensions;
 
     [TestFixture]
     public class ObservableExtensionsTestFixture
@@ -33,11 +33,14 @@ namespace Mercurio.Tests.Extensions
         [Test]
         public void VerifyNullArgumentsThrow()
         {
-            IObservable<int> source = null;
-            Assert.That(() => source.SubscribeAsync(_ => Task.CompletedTask), Throws.ArgumentNullException);
+            using (Assert.EnterMultipleScope())
+            {
+                IObservable<int> source = null;
+                Assert.That(() => source.SubscribeAsync(_ => Task.CompletedTask), Throws.ArgumentNullException);
 
-            var observable = new Subject<int>();
-            Assert.That(() => observable.SubscribeAsync(null), Throws.ArgumentNullException);
+                var observable = new Subject<int>();
+                Assert.That(() => observable.SubscribeAsync(null), Throws.ArgumentNullException);
+            }
         }
 
         [Test]
@@ -59,11 +62,11 @@ namespace Mercurio.Tests.Extensions
 
             await Task.Delay(10);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(results, Is.EqualTo(new[] { 1, 2 }));
                 Assert.That(completed, Is.True);
-            });
+            };
         }
 
         [Test]

--- a/Mercurio.Tests/Extensions/ObservableExtensionsTestFixture.cs
+++ b/Mercurio.Tests/Extensions/ObservableExtensionsTestFixture.cs
@@ -1,0 +1,84 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="ObservableExtensionsTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright 2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace Mercurio.Tests.Extensions
+{
+    using Mercurio.Extensions;
+
+    using System;
+    using System.Collections.Generic;
+    using System.Reactive.Subjects;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class ObservableExtensionsTestFixture
+    {
+        [Test]
+        public void VerifyNullArgumentsThrow()
+        {
+            IObservable<int> source = null;
+            Assert.That(() => source.SubscribeAsync(_ => Task.CompletedTask), Throws.ArgumentNullException);
+
+            var observable = new Subject<int>();
+            Assert.That(() => observable.SubscribeAsync(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public async Task VerifySubscription()
+        {
+            var results = new List<int>();
+            var completed = false;
+            var subject = new Subject<int>();
+
+            using var subscription = subject.SubscribeAsync(x =>
+            {
+                results.Add(x);
+                return Task.CompletedTask;
+            }, onCompleted: () => completed = true);
+
+            subject.OnNext(1);
+            subject.OnNext(2);
+            subject.OnCompleted();
+
+            await Task.Delay(10);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(results, Is.EqualTo(new[] { 1, 2 }));
+                Assert.That(completed, Is.True);
+            });
+        }
+
+        [Test]
+        public async Task VerifyErrorIsHandled()
+        {
+            var subject = new Subject<int>();
+            Exception captured = null;
+
+            using var subscription = subject.SubscribeAsync(_ => Task.FromException(new InvalidOperationException("boom")), ex => captured = ex);
+
+            subject.OnNext(1);
+
+            await Task.Delay(10);
+
+            Assert.That(captured, Is.TypeOf<InvalidOperationException>());
+        }
+    }
+}

--- a/Mercurio.Tests/Extensions/StreamExtensionsTestFixture.cs
+++ b/Mercurio.Tests/Extensions/StreamExtensionsTestFixture.cs
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------------
+//  <copyright file="StreamExtensionsTestFixture.cs" company="Starion Group S.A.">
+//
+//    Copyright 2025 Starion Group S.A.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace Mercurio.Tests.Extensions
+{
+    using Mercurio.Extensions;
+
+    using System.IO;
+
+    [TestFixture]
+    public class StreamExtensionsTestFixture
+    {
+        [Test]
+        public void VerifyNullStreamThrows()
+        {
+            Stream stream = null;
+            Assert.That(() => stream.ToReadOnlyMemory(), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void VerifyMemoryStreamConversion()
+        {
+            var data = new byte[] { 1, 2, 3 };
+            using var stream = new MemoryStream(data);
+            var memory = stream.ToReadOnlyMemory();
+
+            Assert.That(memory.ToArray(), Is.EqualTo(data));
+        }
+
+        [Test]
+        public void VerifyNonMemoryStreamConversion()
+        {
+            var data = new byte[] { 4, 5, 6 };
+            using var memoryStream = new MemoryStream(data);
+            using var stream = new BufferedStream(memoryStream);
+            var memory = stream.ToReadOnlyMemory();
+
+            Assert.That(memory.ToArray(), Is.EqualTo(data));
+        }
+    }
+}

--- a/Mercurio/Extensions/BasicDeliverEventArgsExtensions.cs
+++ b/Mercurio/Extensions/BasicDeliverEventArgsExtensions.cs
@@ -47,6 +47,16 @@ namespace Mercurio.Extensions
         /// </returns>
         public static bool TryReadHeader<T>(this IReadOnlyBasicProperties properties, string header, out T result) where T : class
         {
+            if (properties == null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            if (header == null)
+            {
+                throw new ArgumentNullException(nameof(header));
+            }
+
             result = null;
 
             if (properties.Headers?.TryGetValue(header, out var value) is true)

--- a/Mercurio/Extensions/ObservableExtensions.cs
+++ b/Mercurio/Extensions/ObservableExtensions.cs
@@ -39,7 +39,18 @@ namespace Mercurio.Extensions
         public static IDisposable SubscribeAsync<T>(this IObservable<T> source, Func<T, Task> onNextAsync, Action<Exception> onError = null,
             Action onCompleted = null)
         {
-            return source.Select(x => Observable.FromAsync(() => onNextAsync(x))).Concat().Subscribe(_ => { }, onError ?? (_ => { }), onCompleted ?? (() => { }));
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (onNextAsync == null)
+            {
+                throw new ArgumentNullException(nameof(onNextAsync));
+            }
+
+            return source.Select(x => Observable.FromAsync(() => onNextAsync(x))).Concat()
+                .Subscribe(_ => { }, onError ?? (_ => { }), onCompleted ?? (() => { }));
         }
     }
 }

--- a/Mercurio/Extensions/StreamExtensions.cs
+++ b/Mercurio/Extensions/StreamExtensions.cs
@@ -49,8 +49,7 @@ namespace Mercurio.Extensions
 
             using var temporaryStream = new MemoryStream();
             stream.CopyTo(temporaryStream);
-            temporaryStream.Position = 0;
-            return temporaryStream.ToReadOnlyMemory();
+            return new ReadOnlyMemory<byte>(temporaryStream.ToArray());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Avoid recursion when converting streams to ReadOnlyMemory
- Validate arguments in observable and header extensions
- Cover stream, header, and observable extensions with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a38400448326aff8c2176c5bb084