### PR TITLE
Fix #32: Background service for RPC Server

### DIFF
--- a/Mercurio.Hosting.Tests/MessagingBackgroundServiceTestFixture.cs
+++ b/Mercurio.Hosting.Tests/MessagingBackgroundServiceTestFixture.cs
@@ -38,6 +38,7 @@ namespace Mercurio.Hosting.Tests
     public class MessagingBackgroundServiceTestFixture
     {
         private const string ConfiguredConnectionName = "RabbitMQ";
+        private const string RpcServerQueueName = "RPC";
         private Mock<IConfiguration> configurationMock;
         private TestMessagingBackgroundService backgroundService;
         private ServiceProvider serviceProvider;
@@ -62,6 +63,8 @@ namespace Mercurio.Hosting.Tests
                 .WithSerialization();
 
             serviceCollection.AddScoped<IMessageClientService, MessageClientService>();
+            serviceCollection.AddScoped<IRpcServerService, RpcServerService>();
+            serviceCollection.AddScoped<IRpcClientService<bool>, RpcClientService<bool>>();
             serviceCollection.AddLogging();
             this.serviceProvider = serviceCollection.BuildServiceProvider();
             
@@ -145,6 +148,36 @@ namespace Mercurio.Hosting.Tests
             await Assert.ThatAsync(() => invalidService.StartAsync(CancellationToken.None), Throws.InvalidOperationException);
         }
 
+        [Test]
+        public async Task VerifyRpcServer()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            var rpcBackground = new TestRpcServerBackgrounService(this.serviceProvider, this.serviceProvider.GetRequiredService<ILogger<TestRpcServerBackgrounService>>(), this.configurationMock.Object);
+            _ = rpcBackground.StartAsync(cancellationTokenSource.Token);
+
+            var client = this.serviceProvider.GetRequiredService<IRpcClientService<bool>>();
+            
+            var rpcObservable = await client.SendRequestAsync(ConfiguredConnectionName, RpcServerQueueName, 45, cancellationToken: cancellationTokenSource.Token);
+            var taskCompletion = new TaskCompletionSource<bool>();
+            rpcObservable.Subscribe(result => taskCompletion.SetResult(result));
+            await Task.Delay(50, cancellationTokenSource.Token);
+            
+            await taskCompletion.Task;
+            Assert.That(taskCompletion.Task.Result, Is.False);
+            
+            rpcObservable = await client.SendRequestAsync(ConfiguredConnectionName, RpcServerQueueName, 44, cancellationToken: cancellationTokenSource.Token);
+            var newTaskCompletion = new TaskCompletionSource<bool>();
+            rpcObservable.Subscribe(result => newTaskCompletion.SetResult(result));
+            await Task.Delay(50, cancellationTokenSource.Token);
+            
+            await taskCompletion.Task;
+            Assert.That(newTaskCompletion.Task.Result, Is.True);
+            await cancellationTokenSource.CancelAsync();
+            rpcBackground.Dispose();
+            client.Dispose();
+        }
+
         private class InvalidInitializationBackgroundService : MessagingBackgroundService
         {
             /// <summary>
@@ -204,8 +237,40 @@ namespace Mercurio.Hosting.Tests
                 await this.RegisterAsyncListener(() => this.MessageClientService.ListenAsync<int>(this.ConnectionName, new DirectExchangeConfiguration("BackgroundTestInt")), (x) => 
                 {
                     this.ReceivedMessages.Add(x.ToString());
-                    return Task.CompletedTask; 
+                    return Task.CompletedTask;
                 }, onError: _ => this.ReceivedMessages.Clear());
+            }
+        }
+
+        public class TestRpcServerBackgrounService : RpcServerBackgroundService
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="RpcServerBackgroundService" />
+            /// </summary>
+            /// <param name="serviceProvider">
+            /// The injected <see cref="IServiceProvider" /> that allow to resolve
+            /// <see cref="IMessageClientService" /> instance, even if not registered as scope
+            /// </param>
+            /// <param name="logger">The injected <see cref="ILogger{TCategory}" /> to allow logging</param>
+            /// <param name="configuration">The injected <see cref="IConfiguration" /> to provides configuration information for service initialization</param>
+            public TestRpcServerBackgrounService(IServiceProvider serviceProvider, ILogger<TestRpcServerBackgrounService> logger, IConfiguration configuration) : base(serviceProvider, logger, configuration)
+            {
+            }
+
+            /// <summary>
+            /// Initializes this service (e.g. to set the <see cref="ConnectionName" /> and register subscriptions
+            /// </summary>
+            /// <returns>An awaitable <see cref="Task" /></returns>
+            protected override async Task InitializeAsync()
+            {
+                this.ConnectionName = ConfiguredConnectionName;
+                
+                this.RpcSubscriptions.Add(await this.RpcServerService.ListenForRequestAsync<int, bool>(this.ConnectionName, RpcServerQueueName, OnReceivedMessage));
+            }
+
+            private static Task<bool> OnReceivedMessage(int arg)
+            {
+                return Task.FromResult(arg%2 ==0);
             }
         }
     }

--- a/Mercurio.Hosting/IRpcServerBackgroundService.cs
+++ b/Mercurio.Hosting/IRpcServerBackgroundService.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------------------------------
+//  <copyright file="IRpcClientBackgroundService.cs" company="Starion Group S.A.">
+// 
+//    Copyright 2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace Mercurio.Hosting
+{
+    using Mercurio.Messaging;
+
+    /// <summary>
+    /// The <see cref="IRpcServerBackgroundService"/> is a specific <see cref="IMessagingBackgroundService"/> that provides RPC-server
+    /// features through the <see cref="IRpcServerService"/>
+    /// </summary>
+    public interface IRpcServerBackgroundService: IMessagingBackgroundService
+    {
+    }
+}

--- a/Mercurio.Hosting/RpcServerBackgroundService.cs
+++ b/Mercurio.Hosting/RpcServerBackgroundService.cs
@@ -1,0 +1,74 @@
+﻿// -------------------------------------------------------------------------------------------------
+//  <copyright file="RpcServerBackgroundService.cs" company="Starion Group S.A.">
+// 
+//    Copyright 2025 Starion Group S.A.
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+//  </copyright>
+//  ------------------------------------------------------------------------------------------------
+
+namespace Mercurio.Hosting
+{
+    using Mercurio.Messaging;
+
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// The <see cref="RpcServerBackgroundService" /> is a specific <see cref="MessagingBackgroundService" /> that provides
+    /// RPC server capabilities
+    /// </summary>
+    public abstract class RpcServerBackgroundService : MessagingBackgroundService, IRpcServerBackgroundService
+    {
+        /// <summary>
+        /// Gets the collection of <see cref="IDisposable" /> that stores RPC action to perform that needs to be disposed
+        /// </summary>
+        protected readonly List<IDisposable> RpcSubscriptions = [];
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RpcServerBackgroundService" />
+        /// </summary>
+        /// <param name="serviceProvider">
+        /// The injected <see cref="IServiceProvider" /> that allow to resolve
+        /// <see cref="IMessageClientService" /> instance, even if not registered as scope
+        /// </param>
+        /// <param name="logger">The injected <see cref="ILogger{TCategory}" /> to allow logging</param>
+        /// <param name="configuration">The injected <see cref="IConfiguration" /> to provides configuration information for service initialization</param>
+        protected RpcServerBackgroundService(IServiceProvider serviceProvider, ILogger<RpcServerBackgroundService> logger, IConfiguration configuration)
+            : base(serviceProvider, logger, configuration)
+        {
+            this.RpcServerService = this.ServiceProvider.GetRequiredService<IRpcServerService>();
+        }
+
+        /// <summary>
+        /// Gets the resolved <see cref="IRpcServerService" /> that will provides RPC server features
+        /// </summary>
+        protected IRpcServerService RpcServerService { get; }
+
+        /// <inheritdoc />
+        public override void Dispose()
+        {
+            base.Dispose();
+
+            foreach (var subscription in this.RpcSubscriptions)
+            {
+                subscription.Dispose();
+            }
+            
+            this.RpcSubscriptions.Clear();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Mercurio/Messaging/RpcClientService.cs
+++ b/Mercurio/Messaging/RpcClientService.cs
@@ -265,6 +265,7 @@ namespace Mercurio.Messaging
                     {
                         observer.OnNext(response);
                         activity?.SetStatus(ActivityStatusCode.Ok);
+                        observer.OnCompleted();
                     }
                 }
                 catch (Exception exception)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/Mercurio/pulls) open
- [x] I have verified that I am following the Mercurio [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/Mercurio/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
RPC Server background Service implemented. At the end, no need of Auto-recovery feature for this since the RpcServerService works with events and not IObserable
<!-- Thanks for contributing to Mercurio! -->