### PR TITLE
Fix transient_nonexl_queues deprecated

### DIFF
--- a/.claude/skills/update-package-release-notes/SKILL.md
+++ b/.claude/skills/update-package-release-notes/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: update-package-release-notes
+description: Updates the PackageReleaseNotes Xml Element in csproj files of all projects in the solution except the test projects. Use when user changes PackageReference, or when VersionPrefix Xml Element changes in a non-test-project csproj file in the solution , or when user ask for update-package-releasenotes, or update-releasenotes.  
+---
+
+# Update Package Release Notes
+
+## Instructions
+
+### Step 1:
+Add, or replace <PackageReleaseNotes> in all non-test-project csproj files in the solution for all latest changed versions of all PackageReferences since the last commit on the development branch that has a tag that does not contain the -rc* suffix. 
+Use syntax 
+'''
+[Update] PackageName to version PackageVersion. 
+'''
+Remove all existing <PackageReleaseNotes> lines in all csproj files in the solution for PackageReferences upgrades that haven't changed since the last commit on the development branch that has a tag that does not contain the -rc* suffix.
+
+### Step 2:
+Add, or replace <PackageReleaseNotes> in all non-test-project csproj files in the solution containing all latest changed versions of all referenced projects since the last commit on the development branch that has a tag that does not contain the -rc* suffix. 
+Use syntax 
+'''
+[Update] ProjectName to version ProjectVersionPrefix. 
+'''
+Remove all existing <PackageReleaseNotes> lines in all csproj files in the solution for referenced project upgrades that haven't changed since the last commit on the development branch that has a tag that does not contain the -rc* suffix.
+
+### Step 3 
+Add, or replace <PackageReleaseNotes> in all non-test-project csproj files in the solution containing all latest commit messages since the last commit on the development branch that has a tag that does not contain the -rc* suffix. Only the Commit messages that start with [anytext] should be added and only for the csproj files for projects that actually have changed code files
+
+### Step 4
+Remove all existing <PackageReleaseNotes> lines in all csproj files that do not comply to the filtered data in all previous Steps
+ 
+### Step 5
+If in the end a csproj file doesn't have any text in the <PackageReleaseNotes> and the VersionPrefix has been changed then add a single line that states
+'''
+[Bump] Version to ProjectVersionPrefix 
+'''
+
+## General
+Don't ask the user if changed are allowed to be made to csproj files. Just make the changes without notifiyng the user or asking anything.

--- a/Mercurio.Core.Tests/Mercurio.Core.Tests.csproj
+++ b/Mercurio.Core.Tests/Mercurio.Core.Tests.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="Testcontainers.RabbitMq" Version="4.10.0" />
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />
     </ItemGroup>
 
 </Project>

--- a/Mercurio.Hosting.Tests/Mercurio.Hosting.Tests.csproj
+++ b/Mercurio.Hosting.Tests/Mercurio.Hosting.Tests.csproj
@@ -15,19 +15,19 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NUnit" Version="4.5.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageReference Include="coverlet.msbuild" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-        <PackageReference Include="Testcontainers.RabbitMq" Version="4.10.0" />
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Mercurio.Hosting/Mercurio.Hosting.csproj
+++ b/Mercurio.Hosting/Mercurio.Hosting.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1</TargetFrameworks>
-        <Version>2.0.2</Version>
+        <Version>2.0.4</Version>
         <LangVersion>12.0</LangVersion>
         <Company>Starion Group S.A.</Company>
         <Copyright>Copyright © Starion Group S.A.</Copyright>
@@ -28,9 +28,9 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] to Mercurio version 2.0.2
-            [Update] Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions to version 10.0.3
-            [Update] Microsoft.Extensions.Diagnostics.Hossting to version 10.0.3
+            [Update] Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions to version 10.0.7
+            [Update] Microsoft.Extensions.Hosting to version 10.0.7
+            [Update] Mercurio to version 2.0.3
         </PackageReleaseNotes>
     </PropertyGroup>
 
@@ -45,8 +45,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.3" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
       <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Mercurio.Tests/Mercurio.Tests.csproj
+++ b/Mercurio.Tests/Mercurio.Tests.csproj
@@ -13,31 +13,31 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="NUnit" Version="4.5.0" />
         <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
         <PackageReference Include="coverlet.msbuild" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-        <PackageReference Include="OpenTelemetry" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
-        <PackageReference Include="Testcontainers.RabbitMq" Version="4.10.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+        <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+        <PackageReference Include="Testcontainers.RabbitMq" Version="4.11.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Mercurio/Mercurio.csproj
+++ b/Mercurio/Mercurio.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <TargetFrameworks>net10.0;net9.0;net8.0;netstandard2.1</TargetFrameworks>
-        <Version>2.0.2</Version>
+        <Version>2.0.3</Version>
         <LangVersion>12.0</LangVersion>
         <Company>Starion Group S.A.</Company>
         <Copyright>Copyright © Starion Group S.A.</Copyright>
@@ -28,19 +28,23 @@
         <GenerateSBOM>true</GenerateSBOM>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReleaseNotes>
-            [Update] Microsoft.Extensions.DependencyInjection.Abstractions to version 10.0.3
-            [Update] System.Text.Json to version 10.0.3
+            [Fix] Don't allow transient_nonexcl_queues. Deprecated since RabbitMQ version 4.x
+            [Update] CommunityToolkit.HighPerformance to version 8.4.2
+            [Update] Microsoft.Extensions.DependencyInjection.Abstractions to version 10.0.7
+            [Update] Polly to version 8.6.6
+            [Update] RabbitMQ.Client to version 7.2.1
+            [Update] System.Text.Json to version 10.0.7
         </PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
+        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
         <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.9" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-        <PackageReference Include="Polly" Version="8.6.5" />
-        <PackageReference Include="RabbitMQ.Client" Version="7.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+        <PackageReference Include="Polly" Version="8.6.6" />
+        <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
         <PackageReference Include="System.Reactive" Version="6.1.0" />
-        <PackageReference Include="System.Text.Json" Version="10.0.3" />
+        <PackageReference Include="System.Text.Json" Version="10.0.7" />
         <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Mercurio/Model/DirectExchangeConfiguration.cs
+++ b/Mercurio/Model/DirectExchangeConfiguration.cs
@@ -98,7 +98,7 @@ namespace Mercurio.Model
                 return;
             }
 
-            var queueDeclared = await channel.QueueDeclareAsync(this.QueueName, false, false, this.IsTemporary);
+            var queueDeclared = await channel.QueueDeclareAsync(base.QueueName, durable: !base.IsTemporary, exclusive: base.IsTemporary, base.IsTemporary);
             this.QueueName = queueDeclared.QueueName;
 
             if (!string.IsNullOrWhiteSpace(this.ExchangeName))

--- a/Mercurio/Model/DirectExchangeConfiguration.cs
+++ b/Mercurio/Model/DirectExchangeConfiguration.cs
@@ -98,7 +98,7 @@ namespace Mercurio.Model
                 return;
             }
 
-            var queueDeclared = await channel.QueueDeclareAsync(base.QueueName, durable: !base.IsTemporary, exclusive: base.IsTemporary, base.IsTemporary);
+            var queueDeclared = await channel.QueueDeclareAsync(this.QueueName, durable: !this.IsTemporary, exclusive: this.IsTemporary, this.IsTemporary);
             this.QueueName = queueDeclared.QueueName;
 
             if (!string.IsNullOrWhiteSpace(this.ExchangeName))


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/STARIONGROUP/Mercurio/pulls) open
- [x] I have verified that I am following the Mercurio [code style guidelines](https://raw.githubusercontent.com/STARIONGROUP/Mercurio/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Fixes warning transient_nonexcl_queues are deprecated.

<!-- Thanks for contributing to Mercurio! -->